### PR TITLE
解决对象上属性定义少于 typeclass 属性时报错问题。解决自定义属性重复添加问题。

### DIFF
--- a/muddery/commands/default_cmdsets.py
+++ b/muddery/commands/default_cmdsets.py
@@ -104,6 +104,7 @@ class UnloggedinCmdSet(default_cmds.UnloggedinCmdSet):
         self.add(unloggedin.CmdUnconnectedConnect())
         self.add(unloggedin.CmdUnconnectedQuit())
         self.add(unloggedin.CmdQuickLogin())
+        self.add(unloggedin.CmdUnconnectedConnectT())
 
 
 class SessionCmdSet(default_cmds.SessionCmdSet):

--- a/muddery/server/conf/serversession.py
+++ b/muddery/server/conf/serversession.py
@@ -53,14 +53,15 @@ class ServerSession(BaseServerSession):
 
         if raw:
             out_text = text
+        if self.protocol_key == 'telnet':
+            out_text = str(text)
         else:
+            # set raw=True
+            kwargs["options"].update({"raw": True, "client_raw": True})
             try:
-                out_text = json.dumps({"data": text, "context": context})
+                out_text = json.dumps({"data": text, "context": context}, ensure_ascii=False)
             except Exception as e:
                 out_text = json.dumps({"data": {"err": "There is an error occurred while outputing messages."}})
                 logger.log_tracemsg("json.dumps failed: %s" % e)
-
-        # set raw=True
-        kwargs["options"].update({"raw": True, "client_raw": True})
 
         return super(ServerSession, self).data_out(text=out_text, **kwargs)

--- a/muddery/typeclasses/object.py
+++ b/muddery/typeclasses/object.py
@@ -306,7 +306,7 @@ class MudderyBaseObject(BaseTypeclass, DefaultObject):
         # Set values.
         for key, info in self.get_properties_info().items():
             if not info["mutable"]:
-                self.custom_properties_handler.add(key, values.get(key, info["default"]))
+                self.custom_properties_handler.add(key, values.get(key, ast.literal_eval(info["default"])))
 
         # Set default mutable custom properties.
         self.set_mutable_custom_properties()
@@ -321,9 +321,9 @@ class MudderyBaseObject(BaseTypeclass, DefaultObject):
                 if not self.custom_properties_handler.has(key):
                     default = info["default"]
                     value = ""
-                    if self.custom_properties_handler.has(default):
+                    if self.custom_properties_handler.has(key):
                         # User another property'a value
-                        value = self.custom_properties_handler.get(default)
+                        value = self.custom_properties_handler.get(key)
                     else:
                         try:
                             value = ast.literal_eval(default)


### PR DESCRIPTION
1. 解决对象上属性定义少于 typeclass 属性时报错问题。
2. 解决自定义属性重复添加问题。
3. 增加对于 telnet 协议的支持，手动设置  `TELNET_ENABLED=True' 即可。这个不会改变在 WebSocket 协议下返回的数据格式。只是在 Telnet 协议登录的时候，不做 JSON 封装，不作 RAW 转换