### PR TITLE
Fix a bug when illegal text_data received

### DIFF
--- a/muddery/server/service/session.py
+++ b/muddery/server/service/session.py
@@ -67,8 +67,15 @@ class Session(object):
 
         # Pass messages to the muddery server.
         logger.log_debug("[Receive command][%s]%s" % (self, text_data))
+        
+        # Make sure a correct format
+        data = {}
+        try:
+            data = json.loads(text_data)
+        except Exception as e:
+            self.msg({"msg": "ok"})
+            return
 
-        data = json.loads(text_data)
         command = data["cmd"] if "cmd" in data else None
         args = data["args"] if "args" in data else None
         serial_number = data["sn"] if "sn" in data else None

--- a/muddery/server/service/session.py
+++ b/muddery/server/service/session.py
@@ -73,7 +73,7 @@ class Session(object):
         try:
             data = json.loads(text_data)
         except Exception as e:
-            self.msg({"msg": "ok"})
+            self.msg({"response": {}})
             return
 
         command = data["cmd"] if "cmd" in data else None


### PR DESCRIPTION
当客户端发送了一个字符串而不是符合json格式的请求时，客户端会显示"客户端已经与服务器断开"，可能是这部分代码导致的